### PR TITLE
Update README.md, check clusterRole in rbac.yaml

### DIFF
--- a/helm/nats-streaming-operator/Chart.yaml
+++ b/helm/nats-streaming-operator/Chart.yaml
@@ -1,3 +1,4 @@
+apiVersion: v1
 name: nats-streaming-operator
 version: 1.0.0
 appVersion: 0.2.3

--- a/helm/nats-streaming-operator/README.md
+++ b/helm/nats-streaming-operator/README.md
@@ -60,17 +60,17 @@ their default values.
 | Parameter                            | Description                                                                                  | Default                                         |
 | ------------------------------------ | -------------------------------------------------------------------------------------------- | ----------------------------------------------- |
 | `rbacEnabled`                        | Switch to enable/disable RBAC for this chart                                                 | `true`                                          |
-| `cluster.enabled` | | |
-| `cluster.name` | | |
-| `cluster.version` | | |
-| `cluster.size` | | |
-| `cluster.natsSvc` | | |
-| `cluster.config.debug` | | |
-| `cluster.config.trace` | | |
-| `cluster.config.raftLogging` | | |
-| `cluster.metrics.enabled` | | |
-| `cluster.metrics.image` | | |
-| `cluster.metrics.version` | | |
+| `cluster.enabled`                    | Deploy a NATS Streaming Cluster with the operator                                            | `true`                                          |
+| `cluster.name`                       | Name of the NATS Streaming Cluster                                                           | `nats-streaming-cluster`                        |
+| `cluster.version`                    | Version of the NATS Streaming Cluster                                                        | `0.12.2`                                        |
+| `cluster.size`                       | Number of nodes in the cluster                                                               | `3`                                             |
+| `cluster.natsSvc`                    | NATS cluster service name                                                                    | `nats-cluster`                                  |
+| `cluster.config.debug`               | Enable debug log                                                                             | `true`                                          |
+| `cluster.config.trace`               | Enable tracing                                                                               | `true`                                          |
+| `cluster.config.raftLogging`         | Enable Raft Logging                                                                          | `true`                                          |
+| `cluster.metrics.enabled`            | Enable prometheus metrics exporter                                                           | `true`                                          |
+| `cluster.metrics.image`              | Prometheus metrics exporter image name                                                       | `synadia/prometheus-nats-exporter`              |
+| `cluster.metrics.version`            | Prometheus metrics exporter image tag                                                        | `0.2.0`                                         |
 | `image.registry`                     | NATS Operator image registry                                                                 | `docker.io`                                     |
 | `image.repository`                   | NATS Operator image name                                                                     | `connecteverything/nats-operator`               |
 | `image.tag`                          | NATS Operator image tag                                                                      | `0.4.3-v1alpha2`                                |

--- a/helm/nats-streaming-operator/templates/rbac.yaml
+++ b/helm/nats-streaming-operator/templates/rbac.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbacEnabled }}
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -5,7 +6,11 @@ metadata:
   name: nats-streaming-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.clusterScoped }}
 kind: ClusterRoleBinding
+{{- else }}
+kind: RoleBinding
+{{- end }}
 metadata:
   name: nats-streaming-operator-binding
 roleRef:
@@ -15,10 +20,14 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: nats-streaming-operator
-  namespace: default
+  namespace: {{ .Release.Namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+{{- if .Values.clusterScoped }}
 kind: ClusterRole
+{{- else }}
+kind: Role
+{{- end }}
 metadata:
   name: nats-streaming-operator
 rules:
@@ -56,3 +65,4 @@ rules:
   - endpoints
   - events
   verbs: ["*"]
+{{- end }}


### PR DESCRIPTION
If user specifies `clusterRole=true` we should create a
`ClusterRole/ClusterRoleBinding`, otherwise it should be scoped by
namespace (`Role/RoleBinding`).